### PR TITLE
Fix bug and suggest simplification related to `make_moddict`

### DIFF
--- a/nymserv/nymserv
+++ b/nymserv/nymserv
@@ -957,7 +957,7 @@ def process_config(result, payload):
     # in the master userconf dict.
     moddict = updusr.make_moddict(payload)
     # Does the mod request include a Delete statement?
-    if 'delete' in moddict and moddict['delete'].lower() == 'yes':
+    if 'delete' in moddict and moddict['delete'] is True:
         logmessage = sigfor + ": Starting delete process "
         logmessage += "at user request."
         logging.info(logmessage)

--- a/nymserv/nymserv
+++ b/nymserv/nymserv
@@ -359,9 +359,9 @@ class UpdateUser():
                 continue
             # None or False means set the field to False.
             vlc = value.lower()
-            if vlc == '0' or vlc == 'no' or vlc == 'none' or vlc == 'false':
+            if vlc in '0 no none false'.split():
                 moddict[field] = False
-            elif vlc == '1' or vlc == 'yes' or vlc == 'true':
+            elif vlc in '1 yes true'.split():
                 moddict[field] = True
             else:
                 moddict[field] = value


### PR DESCRIPTION
#### Expect `True` for positive fields of the options dictionary

I recently found a bug when I attempted to delete a nym. I noticed that it was expected to have a string in `moddict['delete']`, but a boolean was found. The first change I made was to just check `if moddict['delete']` because I was expecting that value to be a boolean, but in fact for values that are neither positive nor negative will be just strings and the nym would be deleted (by a user mistake, because the delete option only makes sense to be used with positive values), so I decided to check `if moddict['delete'] is True`. I could not find any other section that expected `'yes'` or any other positive string, but I might be wrong.

That same problem might affect conditionals such as this one in line 1087:

```python
if 'block_sends' in userconf and userconf['block_sends']:
```

Well, the `userconf` is only handled by the server and that value will always be a boolean, but I just would like to highlight the problem of a wrong value passing similar conditionals, as `make_moddict` will assign the actual string if it does not look like a boolean. Do you think there are other sections of the code that might be affected?

#### Simplify parsing of specific string fields by `make_moddict`

This second commit is just a suggestion to parse those specific values which performs slower than the current solution but in my opinion is a lot easier to maintain and I do not think performance is relevant in that case.

Thanks!